### PR TITLE
Updates version number on the front page from `v2.4.0` to the latest version (`v2.6.0`)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -40,28 +40,28 @@ LogicNG is released in the Maven Central Repository. To include the latest versi
     <dependency>
       <groupId>org.logicng</groupId>
       <artifactId>logicng</artifactId>
-      <version>2.4.0</version>
+      <version>2.6.0</version>
     </dependency>
     ```
 
 === "Gradle Groovy DSL"
     ``` groovy
-    implementation 'org.logicng:logicng:2.4.0'
+    implementation 'org.logicng:logicng:2.6.0'
     ```
 
 === "Gradle Kotlin DSL"
     ``` kotlin
-    implementation("org.logicng:logicng:2.4.0")
+    implementation("org.logicng:logicng:2.6.0")
     ```
 
 === "Scala SBT"
     ``` scala
-    libraryDependencies += "org.logicng" % "logicng" % "2.4.0"
+    libraryDependencies += "org.logicng" % "logicng" % "2.6.0"
     ```
 
 === "Leiningen"
     ``` clojure
-    [org.logicng/logicng "2.4.0"]
+    [org.logicng/logicng "2.6.0"]
     ```
 
 


### PR DESCRIPTION
This PR updates the version number of the front page to the latest released version (`v2.6.0`).